### PR TITLE
update share.bash to use password.exchange API v1

### DIFF
--- a/share.bash
+++ b/share.bash
@@ -16,14 +16,14 @@ upload_pass() {
 	
 	# Make API call with timeout and status code checking
 	local response http_code
-	response=$(curl -s --max-time 30 -w "%{http_code}" -X POST \
+	response=$(curl -s --max-time 30 -w "\n%{http_code}" -X POST \
 		-H "Content-Type: application/json" \
 		-d "$json_payload" \
 		"${endpoint}" 2>&1)
 	
-	# Extract HTTP status code from end of response
-	http_code="${response: -3}"
-	response="${response%???}"
+	# Extract HTTP status code and response body
+	http_code=$(echo "$response" | tail -n 1)
+	response=$(echo "$response" | sed '$d')
 	
 	# Check HTTP status code
 	if [[ "$http_code" != "200" && "$http_code" != "201" ]]; then

--- a/share.bash
+++ b/share.bash
@@ -1,17 +1,31 @@
 #!/usr/bin/env bash
-: "${PASSWORD_SHARE_ENDPOINT:=https://password.exchange}"
+: "${PASSWORD_SHARE_ENDPOINT:=https://password.exchange/api/v1}"
 
 upload_pass() {
 	local -r content=$1
 	local -r passphrase=$2
-	local -r endpoint=$PASSWORD_SHARE_ENDPOINT
+	local -r endpoint="${PASSWORD_SHARE_ENDPOINT}/messages"
+	
+	# Prepare JSON payload
+	local json_payload
 	if [[ -z $passphrase ]]; then
-		RESULT=$(curl -d "content=$content&api=on" -L "${endpoint}" 2>&1 | grep -o '"url":"[^"]*' - | grep -o '[^"]*$')
+		json_payload=$(jq -n --arg content "$content" '{content: $content}')
 	else
-		RESULT=$(curl -d "content=$content&other_lastname=$passphrase&api=on" -L "${endpoint}" 2>&1 | grep -o '"url":"[^"]*' - | grep -o '[^"]*$')
+		json_payload=$(jq -n --arg content "$content" --arg passphrase "$passphrase" '{content: $content, passphrase: $passphrase}')
 	fi
+	
+	# Make API call
+	local response
+	response=$(curl -s -X POST \
+		-H "Content-Type: application/json" \
+		-d "$json_payload" \
+		"${endpoint}" 2>&1)
+	
+	# Extract URL from response
+	RESULT=$(echo "$response" | jq -r '.url // empty' 2>/dev/null)
+	
 	if [[ -z $RESULT ]]; then
-		printf "something went wrong with uploading: %s" "${RESULT}"
+		printf "something went wrong with uploading: %s\n" "${response}"
 	else
 		printf "\n%s\n" "${RESULT}"
 	fi

--- a/share.bash
+++ b/share.bash
@@ -14,20 +14,31 @@ upload_pass() {
 		json_payload=$(jq -n --arg content "$content" --arg passphrase "$passphrase" '{content: $content, passphrase: $passphrase}')
 	fi
 	
-	# Make API call
-	local response
-	response=$(curl -s -X POST \
+	# Make API call with timeout and status code checking
+	local response http_code
+	response=$(curl -s --max-time 30 -w "%{http_code}" -X POST \
 		-H "Content-Type: application/json" \
 		-d "$json_payload" \
 		"${endpoint}" 2>&1)
+	
+	# Extract HTTP status code from end of response
+	http_code="${response: -3}"
+	response="${response%???}"
+	
+	# Check HTTP status code
+	if [[ "$http_code" != "200" && "$http_code" != "201" ]]; then
+		printf "API request failed with HTTP %s: %s\n" "$http_code" "$response" >&2
+		return 1
+	fi
 	
 	# Extract URL from response
 	RESULT=$(echo "$response" | jq -r '.url // empty' 2>/dev/null)
 	
 	if [[ -z $RESULT ]]; then
-		printf "something went wrong with uploading: %s\n" "${response}"
+		printf "API request failed or returned invalid response: %s\n" "$response" >&2
+		return 1
 	else
-		printf "\n%s\n" "${RESULT}"
+		printf "\n%s\n" "$RESULT"
 	fi
 }
 prepare_pass() {


### PR DESCRIPTION
- Change endpoint to /api/v1/messages
- Switch from form data to JSON payload format
- Use proper Content-Type header for JSON requests
- Update passphrase parameter name from other_lastname to passphrase
- Improve response parsing with jq for better error handling

🤖 Generated with [Claude Code](https://claude.ai/code)